### PR TITLE
Updates to backlight management and standalone/hosted mode transitions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,8 +9,8 @@ that source won't show up until tests are actually running, so you'll
 need to configure the control surface manually while you're running
 tests for the first time.
 
-You can add the test control surface in addition to the main SSCOM
-control surface, if you don't want to deal with switching the
+You can safely add this test control surface alongside your primary
+modeStep control surface, if you don't want to deal with switching the
 input/output when you want to run tests.
 
 To run tests, use:
@@ -25,13 +25,19 @@ For debug output:
 DEBUG=1 make test
 ```
 
+To run only specs tagged with `@now`:
+
+```shell
+.venv/bin/pytest -m now
+```
+
 ## Linting and type checks
 
 Before submitting a PR, make sure the following are passing:
 
 ```shell
-make lint # Validates code style
-make check # Validates types
+make lint # Validates code style.
+make check # Validates types.
 ```
 
 Some lint errors can be fixed automatically with:

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 SYSTEM_MIDI_REMOTE_SCRIPTS_DIR := /Applications/Ableton\ Live\ 12\ Suite.app/Contents/App-Resources/MIDI\ Remote\ Scripts
-TEST_PROJECT_DIR = tests/modeStep_tests_project
+
+TEST_PROJECT_SET_NAMES := backlight default overrides standalone wide_clip_launch
+TEST_PROJECT_DIR := tests/modeStep_tests_project
+TEST_PROJECT_SETS := $(addprefix $(TEST_PROJECT_DIR)/, $(addsuffix .als, $(TEST_PROJECT_SET_NAMES)))
 
 .PHONY: deps
 deps: __ext__/System_MIDIRemoteScripts/.make.decompile .make.pip-install
@@ -19,7 +22,7 @@ check: .make.pip-install __ext__/System_MIDIRemoteScripts/.make.decompile
 	.venv/bin/pyright .
 
 .PHONY: test
-test: .make.pip-install $(TEST_PROJECT_DIR)/default.als $(TEST_PROJECT_DIR)/overrides.als $(TEST_PROJECT_DIR)/standalone.als $(TEST_PROJECT_DIR)/wide_clip_launch.als
+test: .make.pip-install $(TEST_PROJECT_SETS)
 	.venv/bin/pytest
 
 .PHONY: img

--- a/control_surface/__init__.py
+++ b/control_surface/__init__.py
@@ -186,9 +186,9 @@ class Specification(ControlSurfaceSpecification):
     # Force the controller into standalone mode when exiting (this will be redundant if
     # a standalone mode is already active.) The disconnect program change message will
     # be appended below, if configured.
-    goodbye_messages: typing.Collection[typing.Tuple[int, ...]] = (
-        SYSEX_STANDALONE_MODE_ON_REQUESTS
-    )
+    goodbye_messages: typing.Collection[
+        typing.Tuple[int, ...]
+    ] = SYSEX_STANDALONE_MODE_ON_REQUESTS
     send_goodbye_messages_last = True
 
     component_map = {
@@ -468,4 +468,3 @@ class modeStep(ControlSurface):
                 standalone_sysex._deferred_message = None
         finally:
             self.__is_suppressing_hardware = old_suppressing_hardware
-

--- a/control_surface/__init__.py
+++ b/control_surface/__init__.py
@@ -47,6 +47,8 @@ from .session_ring import SessionRingComponent
 from .sysex import (
     DEVICE_FAMILY_BYTES,
     MANUFACTURER_ID_BYTES,
+    SYSEX_BACKLIGHT_OFF_REQUEST,
+    SYSEX_BACKLIGHT_ON_REQUEST,
     SYSEX_STANDALONE_MODE_ON_REQUESTS,
 )
 from .track_controls import TrackControlsComponent, TrackControlsState
@@ -233,6 +235,15 @@ class modeStep(ControlSurface):
             specification.goodbye_messages = [
                 *specification.goodbye_messages,
                 (0xC0, self._configuration.disconnect_program),
+            ]
+        if self._configuration.disconnect_backlight is not None:
+            specification.goodbye_messages = [
+                *specification.goodbye_messages,
+                (
+                    SYSEX_BACKLIGHT_ON_REQUEST
+                    if self._configuration.disconnect_backlight
+                    else SYSEX_BACKLIGHT_OFF_REQUEST
+                ),
             ]
 
         # Internal tracker during connect/reconnect events.

--- a/control_surface/colors.py
+++ b/control_surface/colors.py
@@ -225,6 +225,9 @@ class Skin:
         class On:
             On = TOGGLE_ON
 
+        class Unset:
+            On = TOGGLE_OFF
+
     class Mixer:
         ArmOn = GREEN_ON
         ArmOff = RED_ON

--- a/control_surface/configuration.py
+++ b/control_surface/configuration.py
@@ -63,10 +63,6 @@ class Configuration(NamedTuple):
 
     # Backlight on/off state (or `None` to leave it unmanaged) to be set at
     # startup.
-    #
-    # Note as of SoftStep firmware v2.0.3, you might see some weird LED behavior
-    # when using the backlight with modeStep. This appears to be a bug in the
-    # firmware (since it also happens when using the SoftStep editor).
     backlight: Optional[bool] = None
 
     # Backlight on/off state (or `None` to leave it unmanaged) to be set at

--- a/control_surface/configuration.py
+++ b/control_surface/configuration.py
@@ -61,8 +61,17 @@ class Configuration(NamedTuple):
     # may override this behavior.
     auto_arm: bool = False
 
-    # Whether to turn on the backlight. Can be toggled from utility mode.
-    backlight: bool = False
+    # Backlight on/off state (or `None` to leave it unmanaged) to be set at
+    # startup.
+    #
+    # Note as of SoftStep firmware v2.0.3, you might see some weird LED behavior
+    # when using the backlight with modeStep. This appears to be a bug in the
+    # firmware (since it also happens when using the SoftStep editor).
+    backlight: Optional[bool] = None
+
+    # Backlight on/off state (or `None` to leave it unmanaged) to be set at
+    # exit.
+    disconnect_backlight: Optional[bool] = None
 
     # Add a behavior when long pressing a clip (currently just "stop_track_clips" is available).
     clip_long_press_action: Optional[ClipSlotAction] = None
@@ -237,7 +246,8 @@ def get_configuration(song) -> Configuration:
 ElementOverride = Tuple[str, str, str]
 
 ##
-# Helpers for overriding elements. Keys are the physical key numbers on the SoftStep.
+# Helpers for overriding elements, see above for usage examples. Keys are the
+# physical key numbers on the SoftStep.
 
 
 # Override a key with an action.

--- a/control_surface/elements/sysex.py
+++ b/control_surface/elements/sysex.py
@@ -26,9 +26,6 @@ class SysexToggleElement(SysexButtonElement):
         self._off_messages = off_messages
         assert len(on_messages) > 0 and len(off_messages) > 0
 
-        # Store the last value to `set_light` to avoid sending unnecessary messages.
-        self._last_value: Optional[bool] = None
-
         super().__init__(
             *a,
             # Messages just get passed directly to send_value.
@@ -40,19 +37,8 @@ class SysexToggleElement(SysexButtonElement):
             **k,
         )
 
-    def _on_resource_received(self, client, *a, **k):
-        # Make sure we send our initial message. Since sending sysexes can cause
-        # momentary performance issues and other weirdness on the device, try to avoid
-        # disconnecting/reconnecting resources too often.
-        self._last_value = None
-        return super()._on_resource_received(client, *a, **k)
-
     def set_light(self, value):
         assert isinstance(value, bool)
-
-        # Avoid re-sending these on every update.
-        if value != self._last_value:
-            messages = self._on_messages if value else self._off_messages
-            for message in messages:
-                self.send_value(message)
-        self._last_value = value
+        messages = self._on_messages if value else self._off_messages
+        for message in messages:
+            self.send_value(message)

--- a/control_surface/elements/sysex.py
+++ b/control_surface/elements/sysex.py
@@ -10,10 +10,6 @@ logger = logging.getLogger(__name__)
 
 
 class SysexButtonElement(SysexElement, ButtonElementMixin):
-    # def send_value(self, *a, **k):
-    #     logger.info(f"SEND from {self.name}")
-    #     return super().send_value(*a, **k)
-
     def is_momentary(self):
         return False
 
@@ -48,13 +44,15 @@ class SysexToggleElement(SysexButtonElement):
         )
 
     # This can get called via `set_light`, or from elsewhere within the framework.
-    def send_value(self, value):
+    def send_value(self, *a, **k):
+        assert len(a) == 1
+        value = a[0]
         assert isinstance(value, bool)
 
         # Send multiple messages by calling the parent repeatedly.
         messages = self._on_messages if value else self._off_messages
         for message in messages:
-            super().send_value(message)
+            super().send_value(message, *a[1:], **k)
 
         self.notify_send_value(value)
 

--- a/control_surface/hardware.py
+++ b/control_surface/hardware.py
@@ -102,16 +102,7 @@ class HardwareComponent(Component):
 
     def _update_standalone(self):
         if self.is_enabled():
-            # Only send the standalone/hosted toggle when necessary, since it causes
-            # weirdness with the LEDs and occasional performance issues. Note the
-            # `ColorSysexControl` also sends the value once immediately when a control
-            # element is connected - so to avoid false negatives on dis/reconnect, the
-            # control element must be disconnected when the physical device is
-            # disconnected. This is accomplished by entering `_disabled` mode when an
-            # identity request times out.
-            if self._standalone != self.standalone_sysex.color:
-                self.standalone_sysex.color = self._standalone
-
+            self.standalone_sysex.color = self._standalone
             self._update_standalone_program()
 
     def _update_standalone_program(self):

--- a/control_surface/hardware.py
+++ b/control_surface/hardware.py
@@ -9,11 +9,27 @@ from ableton.v3.control_surface.controls import ButtonControl
 logger = logging.getLogger(__name__)
 
 
+# A sysex which accepts a null color to represent an unmanaged property.
+class NullableColorSysexControl(ColorSysexControl):
+    class State(ColorSysexControl.State):
+        def __init__(self, color=None, *a, **k):
+            super().__init__(color, *a, **k)
+
+            # The parent sets this to "DefaultButton.Disabled" by default, override with
+            # actual `None`.
+            if color is None:
+                self.color = color
+
+        def _send_current_color(self):
+            if self.color is not None:
+                return super()._send_current_color()
+
+
 class HardwareComponent(Component):
     # These are expected to be mapped to `ToggleSysexElement`s or,
     # more specifically, to sysex elements which accept boolean values
     # as colors.
-    backlight_sysex: ColorSysexControl.State = ColorSysexControl(color=False)  # type: ignore
+    backlight_sysex: ColorSysexControl.State = NullableColorSysexControl(color=None)  # type: ignore
     standalone_sysex: ColorSysexControl.State = ColorSysexControl(color=False)  # type: ignore
 
     ping_button: Any = ButtonControl()
@@ -35,11 +51,11 @@ class HardwareComponent(Component):
 
         # Initial values for device properties - these will get set externally when
         # actually setting up this component.
-        self._backlight: bool = False
+        self._backlight: Optional[bool] = None  # None for unmanaged.
         self._standalone: bool = False
 
     @property
-    def backlight(self) -> bool:
+    def backlight(self) -> Optional[bool]:
         return self._backlight
 
     @backlight.setter

--- a/control_surface/mappings.py
+++ b/control_surface/mappings.py
@@ -272,8 +272,8 @@ class MappingsFactory:
         mappings: Mappings = {}
 
         mappings["Hardware"] = dict(
-            # Turn on by default, and shouldn't be toggled except when entering/exiting
-            # `_disabled` mode, to avoid sending unnecessary sysexes.
+            # Turned on by default, so we don't need to enable it everywhere. This
+            # shouldn't be toggled except when entering/exiting `_disabled` mode.
             enable=True,
             # Permanent hardware mappings.
             backlight_sysex="backlight_sysex",

--- a/control_surface/mode.py
+++ b/control_surface/mode.py
@@ -7,7 +7,6 @@ from enum import Enum
 from functools import partial
 from time import time
 
-from ableton.v2.control_surface.mode import SetAttributeMode
 from ableton.v3.base import depends, listenable_property, memoize
 from ableton.v3.control_surface.controls import ButtonControl
 from ableton.v3.control_surface.mode import (

--- a/control_surface/mode.py
+++ b/control_surface/mode.py
@@ -77,11 +77,15 @@ def get_index_str(name: str):
     return name.split("_")[-1]
 
 
-class SetMutableAttributeMode(SetAttributeMode):
-    # Set the attribute regardless of whether it's changed.
+class InvertedMode(Mode):
+    def __init__(self, mode: Mode):
+        self._mode = mode
+
+    def enter_mode(self):
+        self._mode.leave_mode()
+
     def leave_mode(self):
-        assert self._attribute
-        setattr(self._get_object(), self._attribute, self._old_value)
+        self._mode.enter_mode()
 
 
 # The mode select button:
@@ -195,17 +199,6 @@ class ReleaseBehaviour(ModeButtonBehaviour):
                 button.mode_unselected_color = f"{mode_color_base_name}.PressDelayed"
             else:
                 button.mode_unselected_color = f"{mode_color_base_name}.Off"
-
-
-class InvertedMode(Mode):
-    def __init__(self, mode: Mode):
-        self._mode = mode
-
-    def enter_mode(self):
-        self._mode.leave_mode()
-
-    def leave_mode(self):
-        self._mode.enter_mode()
 
 
 class MainModesComponent(ModesComponentBase):

--- a/tests/backlight.feature
+++ b/tests/backlight.feature
@@ -1,0 +1,27 @@
+Feature: Backlight management
+  Scenario Outline: Toggling the backlight when it is unconfigured
+    Given the <set_name> set is open
+    And the SS2 is initialized
+
+    Then the backlight should be <initial_state>
+    And the display should be "Trns"
+
+    When I press key 0
+    And I long-press key 9
+    Then the display should be "Util"
+    And light 6 should be solid <initial_color>
+
+    When I press key 6
+    Then light 6 should be solid <toggle_color>
+    And the display should be "<toggle_disp>"
+    And the backlight should be <toggle_state>
+
+    When I press key 6
+    Then light 6 should be solid <initial_color>
+    And the display should be "<toggle2_disp>"
+    And the backlight should be <toggle2_state>
+
+  Examples:
+    | set_name  | initial_state | toggle_state | toggle2_state | toggle_disp | toggle2_disp | initial_color | toggle_color |
+    | default   | unmanaged     | on           | off           | +BaK        | -BaK         | red           | green        |
+    | backlight | on            | off          | on            | -BaK        | +BaK         | green         | red          |

--- a/tests/basics.feature
+++ b/tests/basics.feature
@@ -57,22 +57,3 @@ Feature: Basic usage
 
     When I long-press key 0
     Then the display should be "Expr"
-
-  Scenario: Toggling the backlight
-    Then the backlight should be off
-    And the display should be "Trns"
-
-    When I press key 0
-    And I long-press key 9
-    Then the display should be "Util"
-    And light 6 should be solid red
-
-    When I press key 6
-    Then light 6 should be solid green
-    And the display should be "+BaK"
-    And the backlight should be on
-
-    When I press key 6
-    Then light 6 should be solid red
-    And the display should be "-BaK"
-    And the backlight should be off

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -404,10 +404,11 @@ def ioport():
         yield ioport
 
 
-# Relay port to the physical device for visual feedback during tests, if available.
+# Cheap thrills - relay the test port to the physical device for visual feedback during
+# tests, if available.
 @fixture
 def relay_port() -> Generator[Optional[mido.ports.BaseOutput], Never, None]:
-    port_name = "SSCOM Port 1"
+    port_name = "SoftStep Control Surface"
     try:
         with mido.open_output(port_name) as relay_port:  # type: ignore
             yield relay_port

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -773,6 +773,11 @@ def should_be_backlight_off(device_state: DeviceState):
     assert device_state.backlight is False
 
 
+@then("the backlight should be unmanaged")
+def should_be_backlight_unmanaged(device_state: DeviceState):
+    assert device_state.backlight is None
+
+
 @then("the SS2 should be in standalone mode")
 def should_be_standalone_mode(device_state: DeviceState):
     assert all([t is True for t in device_state.standalone_toggles])

--- a/tests/modeStep_tests_project/create_set.py
+++ b/tests/modeStep_tests_project/create_set.py
@@ -25,6 +25,7 @@ else:
 
 configurations: Dict[str, Configuration] = {
     "default": Configuration(),
+    "backlight": Configuration(backlight=True),
     "overrides": Configuration(
         override_elements={
             "transport": [

--- a/tests/test_backlight.py
+++ b/tests/test_backlight.py
@@ -1,0 +1,3 @@
+from pytest_bdd import scenarios
+
+scenarios("backlight.feature")


### PR DESCRIPTION
- Works around an apparent firmware issue where LED states get
  corrupted a few seconds after turning the backlight on or off.
- Allows `None` as a configured backlight value, if you don't want
  modeStep to manage the backlight at all by default.
- Adds a separate config option to set the backlight state (or not) on
  disconnect.
- Cleans up standalone/hosted mode transition logic a bit.
- Prevents unnecssary standalone background program change messages
  from being sent when entering standalone modes.