### PR TITLE
ci: use pycdc to generate types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@ __pycache__/
 # Decompiled system scripts.
 /__ext__/System_MIDIRemoteScripts/
 
+# Link to compiled system scripts directory.
+/__ext__/System_MIDIRemoteScripts_compiled
+
 # Markers for Makefile tasks which would otherwise have no artifacts.
 /.make.*
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "__ext__/pycdc"]
+	path = __ext__/pycdc
+	url = https://github.com/zrax/pycdc.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "__ext__/pycdc"]
 	path = __ext__/pycdc
-	url = https://github.com/zrax/pycdc.git
+	url = https://github.com/kmontag/pycdc.git

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,6 +47,10 @@ make lint # Validates code style.
 make check # Validates types.
 ```
 
+To perform the type checks, Live's control surface libraries will be decompiled. A local
+Live 12 installation (any edition) is required. `cmake` and a C++ compilation stack are
+also required to build the decompiler.
+
 Some lint errors can be fixed automatically with:
 
 ```shell

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,6 +3,9 @@
 modeStep uses [poetry](https://python-poetry.org/) for project management and
 development tasks. The project's `Makefile` also contains targets for common tasks.
 
+Note: the `Makefile` currently assumes that Live 12 is installed at its default MacOS
+install location. PRs welcome for better Windows support.
+
 ## Testing
 
 Tests work by opening Live, impersonating the MIDI output of the SoftStep, and checking


### PR DESCRIPTION
This seemed potentially fruitful but there are too many unsupported instructions with `pycdc` to make for useful output.